### PR TITLE
Option to Copy/Duplicate server profile

### DIFF
--- a/ShadowsocksX-NG/Base.lproj/PreferencesWindowController.xib
+++ b/ShadowsocksX-NG/Base.lproj/PreferencesWindowController.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
         <capability name="box content view" minToolsVersion="7.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesWindowController" customModule="ShadowsocksX_NG" customModuleProvider="target">
@@ -26,7 +27,7 @@
         <window title="Server Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <rect key="contentRect" x="423" y="365" width="590" height="330"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1418"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="590" height="330"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -70,6 +71,7 @@
                                     <connections>
                                         <outlet property="dataSource" destination="-2" id="fz3-X6-PbB"/>
                                         <outlet property="delegate" destination="-2" id="6zR-v1-wZj"/>
+                                        <outlet property="menu" destination="QmU-th-vjP" id="J0d-c9-pYs"/>
                                     </connections>
                                 </tableView>
                             </subviews>
@@ -339,6 +341,17 @@ DQ
             <real key="minimum" value="1"/>
             <real key="maximum" value="65535"/>
         </numberFormatter>
+        <menu showsStateColumn="NO" id="QmU-th-vjP">
+            <items>
+                <menuItem title="Duplicate" id="bl9-lq-u9V">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="duplicate:" target="-2" id="dEb-Dt-yBW"/>
+                    </connections>
+                </menuItem>
+            </items>
+            <point key="canvasLocation" x="-25.5" y="171.5"/>
+        </menu>
     </objects>
     <resources>
         <image name="NSAddTemplate" width="11" height="11"/>

--- a/ShadowsocksX-NG/PreferencesWindowController.swift
+++ b/ShadowsocksX-NG/PreferencesWindowController.swift
@@ -114,6 +114,20 @@ class PreferencesWindowController: NSWindowController
         window?.performClose(self)
     }
     
+    @IBAction func duplicate(_ sender: Any) {
+        let profile = profileMgr.profiles[profilesTableView.clickedRow]
+        let duplicateProfile = profile.copy() as! ServerProfile
+        duplicateProfile.uuid = UUID().uuidString
+        profileMgr.profiles.insert(duplicateProfile, at: profilesTableView.clickedRow+1)
+        profilesTableView.beginUpdates()
+        let index = IndexSet(integer: profileMgr.profiles.count-1)
+        profilesTableView.insertRows(at: index, withAnimation: .effectFade)
+        self.profilesTableView.scrollRowToVisible(profilesTableView.clickedRow+1)
+        self.profilesTableView.selectRowIndexes(index, byExtendingSelection: false)
+        profilesTableView.endUpdates()
+        updateProfileBoxVisible()
+    }
+    
     @IBAction func copyCurrentProfileURL2Pasteboard(_ sender: NSButton) {
         let index = profilesTableView.selectedRow
         if  index >= 0 {

--- a/ShadowsocksX-NG/ServerProfile.swift
+++ b/ShadowsocksX-NG/ServerProfile.swift
@@ -10,7 +10,8 @@ import Cocoa
 
 
 
-class ServerProfile: NSObject {
+class ServerProfile: NSObject, NSCopying {
+    
     var uuid: String
     
     var serverHost: String = ""
@@ -26,6 +27,17 @@ class ServerProfile: NSObject {
     
     init(uuid: String) {
         self.uuid = uuid
+    }
+    
+    public func copy(with zone: NSZone? = nil) -> Any {
+        let copy = ServerProfile()
+        copy.serverHost = self.serverHost
+        copy.serverPort = self.serverPort
+        copy.method = self.method
+        copy.password = self.password
+        copy.remark = self.remark
+        copy.ota = self.ota
+        return copy;
     }
     
     static func fromDictionary(_ data:[String:AnyObject]) -> ServerProfile {

--- a/ShadowsocksX-NG/zh-Hans.lproj/PreferencesWindowController.strings
+++ b/ShadowsocksX-NG/zh-Hans.lproj/PreferencesWindowController.strings
@@ -34,3 +34,6 @@
 
 /* Class = "NSButtonCell"; title = "OK"; ObjectID = "zPE-oD-PwK"; */
 "zPE-oD-PwK.title" = "确定";
+
+/* Class = "NSMenuItem"; title = "Duplicate"; ObjectID = "bl9-lq-u9V"; */
+"bl9-lq-u9V.title" = "复制";


### PR DESCRIPTION
 - Added an option to copy/duplicate a server profile on Server Preferences Panel
 - Right clicking a server profile will show a menu with an option to duplicate like below screen shot
![screen shot 2017-01-05 at 9 27 03 pm](https://cloud.githubusercontent.com/assets/12063704/21682239/7c9f76d2-d38e-11e6-80d7-dd62c17fa3b6.png)
 - On selecting Duplicate option selected server profile will be duplicated and added to the profile list with a different UDID
 - Added CH translation for the new text as well
