### PR TITLE
using GDC aync to avoid freeze of operation on show current QR

### DIFF
--- a/ShadowsocksX-NG/AppDelegate.swift
+++ b/ShadowsocksX-NG/AppDelegate.swift
@@ -236,16 +236,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         if let profile = ServerProfileManager.instance.getActiveProfile() {
             if profile.isValid() {
                 // Show window
-                if qrcodeWinCtrl != nil{
-                    qrcodeWinCtrl.close()
+                DispatchQueue.global().async {
+                    if self.qrcodeWinCtrl != nil{
+                        self.qrcodeWinCtrl.close()
+                    }
+                    self.qrcodeWinCtrl = SWBQRCodeWindowController(windowNibName: "SWBQRCodeWindowController")
+                    self.qrcodeWinCtrl.qrCode = profile.URL()!.absoluteString
+                    DispatchQueue.main.async {
+                        self.qrcodeWinCtrl.showWindow(self)
+                        NSApp.activate(ignoringOtherApps: true)
+                        self.qrcodeWinCtrl.window?.makeKeyAndOrderFront(nil)
+                    }
                 }
-                qrcodeWinCtrl = SWBQRCodeWindowController(windowNibName: "SWBQRCodeWindowController")
-                qrcodeWinCtrl.qrCode = profile.URL()!.absoluteString
-                qrcodeWinCtrl.title = profile.title()
-                qrcodeWinCtrl.showWindow(self)
-                NSApp.activate(ignoringOtherApps: true)
-                qrcodeWinCtrl.window?.makeKeyAndOrderFront(nil)
-                
                 return
             } else {
                 errMsg = "Current server profile is not valid.".localized


### PR DESCRIPTION
currently UI freeze when click show current server profile in QR. Try GCD to avoid it.