### PR TITLE
remove keeplive key from plist, update shell script adding launchctl …

### DIFF
--- a/ShadowsocksX-NG/LaunchAgentUtils.swift
+++ b/ShadowsocksX-NG/LaunchAgentUtils.swift
@@ -60,7 +60,6 @@ func generateSSLocalLauchAgentPlist() -> Bool {
     let dict: NSMutableDictionary = [
         "Label": "com.qiuyuzhou.shadowsocksX-NG.local",
         "WorkingDirectory": NSHomeDirectory() + APP_SUPPORT_DIR,
-        "KeepAlive": true,
         "StandardOutPath": logFilePath,
         "StandardErrorPath": logFilePath,
         "ProgramArguments": arguments,
@@ -203,7 +202,6 @@ func generatePrivoxyLauchAgentPlist() -> Bool {
     let dict: NSMutableDictionary = [
         "Label": "com.qiuyuzhou.shadowsocksX-NG.http",
         "WorkingDirectory": NSHomeDirectory() + APP_SUPPORT_DIR,
-        "KeepAlive": true,
         "StandardOutPath": logFilePath,
         "StandardErrorPath": logFilePath,
         "ProgramArguments": arguments
@@ -358,7 +356,6 @@ func generateKcptunLauchAgentPlist() -> Bool {
     let dict: NSMutableDictionary = [
         "Label": "com.qiuyuzhou.shadowsocksX-NG.kcptun",
         "WorkingDirectory": NSHomeDirectory() + APP_SUPPORT_DIR,
-        "KeepAlive": true,
         "StandardOutPath": logFilePath,
         "StandardErrorPath": logFilePath,
         "ProgramArguments": arguments,

--- a/ShadowsocksX-NG/start_kcptun.sh
+++ b/ShadowsocksX-NG/start_kcptun.sh
@@ -7,3 +7,4 @@
 #  Copyright © 2017年 qiuyuzhou. All rights reserved.
 
 launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.kcptun.plist"
+launchctl start com.qiuyuzhou.shadowsocksX-NG.kcptun

--- a/ShadowsocksX-NG/start_privoxy.sh
+++ b/ShadowsocksX-NG/start_privoxy.sh
@@ -7,3 +7,4 @@
 #  Copyright © 2016年 zhfish. All rights reserved.
 
 launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
+launchctl start com.qiuyuzhou.shadowsocksX-NG.http

--- a/ShadowsocksX-NG/start_ss_local.sh
+++ b/ShadowsocksX-NG/start_ss_local.sh
@@ -7,3 +7,4 @@
 #  Copyright © 2016年 qiuyuzhou. All rights reserved.
 
 launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
+launchctl start com.qiuyuzhou.shadowsocksX-NG.local

--- a/ShadowsocksX-NG/stop_kcptun.sh
+++ b/ShadowsocksX-NG/stop_kcptun.sh
@@ -6,4 +6,5 @@
 #  Created by 邱宇舟 on 2017/1/11.
 #  Copyright © 2017年 qiuyuzhou. All rights reserved.
 
+launchctl stop com.qiuyuzhou.shadowsocksX-NG.kcptun
 launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.kcptun.plist"

--- a/ShadowsocksX-NG/stop_privoxy.sh
+++ b/ShadowsocksX-NG/stop_privoxy.sh
@@ -6,6 +6,5 @@
 #  Created by 王晨 on 16/10/7.
 #  Copyright © 2016年 zhfish. All rights reserved.
 
-
-
+launchctl stop com.qiuyuzhou.shadowsocksX-NG.http
 launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"

--- a/ShadowsocksX-NG/stop_ss_local.sh
+++ b/ShadowsocksX-NG/stop_ss_local.sh
@@ -6,6 +6,5 @@
 #  Created by 邱宇舟 on 16/6/6.
 #  Copyright © 2016年 qiuyuzhou. All rights reserved.
 
-
-
+launchctl stop com.qiuyuzhou.shadowsocksX-NG.local
 launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"


### PR DESCRIPTION
…start/stop command

keeplive key  makes the services of shadowsocks-ng automatically start when logining system
Replace the original way with launchctl start/stop, then start the services when needed as shadowsocks-ng using

keeplive 属性使得plist提供的服务在os x系统启动后，自动开启了ss local等进程并监听端口。
load 和 unload是用来加载 plist服务，start 和 stop 是运行和关闭服务，而keeplive将会自动start服务，并且每次开系统都会。因此，
修改将keeplive移除，通过launchctl start 和stop方式开启和关闭服务，这样保证在shadowsocks-ng 使用必要服务时，才去启动相应的进程并监听相应的端口。
优化系统启动时的服务加载，更合理使用launchd