### PR TITLE
Increase status bar icon width from 20pt to 30pt

### DIFF
--- a/ShadowsocksX-NG/AppDelegate.swift
+++ b/ShadowsocksX-NG/AppDelegate.swift
@@ -48,7 +48,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     let kProfileMenuItemIndexBase = 100
 
     var statusItem: NSStatusItem!
-    static let StatusItemIconWidth:CGFloat = 30
+    static let StatusItemIconWidth: CGFloat = NSVariableStatusItemLength
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         

--- a/ShadowsocksX-NG/AppDelegate.swift
+++ b/ShadowsocksX-NG/AppDelegate.swift
@@ -48,7 +48,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     let kProfileMenuItemIndexBase = 100
 
     var statusItem: NSStatusItem!
-    static let StatusItemIconWidth:CGFloat = 20
+    static let StatusItemIconWidth:CGFloat = 30
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         


### PR DESCRIPTION
30pt is more consistent with system status bar icons.
30pt 更能与系统图标宽度保持一致，看起来更协调。不是吗？:)

![2017-07-21 10 13 08](https://user-images.githubusercontent.com/4470629/28446491-9cc4c20a-6dfd-11e7-8a8b-a8e58ec5544f.png)
