### PR TITLE
Fixes #426 Save network interface configuration

### DIFF
--- a/ShadowsocksX-NG/ProxyInterfacesViewCtrl.swift
+++ b/ShadowsocksX-NG/ProxyInterfacesViewCtrl.swift
@@ -68,5 +68,8 @@ class ProxyInterfacesViewCtrl: NSViewController, NSTableViewDataSource, NSTableV
         } else {
             selectedNetworkServices.remove(key)
         }
+
+        UserDefaults.standard.set(selectedNetworkServices.allObjects,
+                                  forKey: "Proxy4NetworkServices")
     }
 }


### PR DESCRIPTION
In the Preferences window, `selectedNetworkServices` of the Interfaces tab is not saved.