### PR TITLE
Fixes #433 Implements SIP002 QR code

### DIFF
--- a/ShadowsocksX-NG/AppDelegate.swift
+++ b/ShadowsocksX-NG/AppDelegate.swift
@@ -241,6 +241,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
                 }
                 qrcodeWinCtrl = SWBQRCodeWindowController(windowNibName: "SWBQRCodeWindowController")
                 qrcodeWinCtrl.qrCode = profile.URL()!.absoluteString
+                qrcodeWinCtrl.legacyQRCode = profile.URL(legacy: true)!.absoluteString
                 qrcodeWinCtrl.title = profile.title()
                 qrcodeWinCtrl.showWindow(self)
                 NSApp.activate(ignoringOtherApps: true)

--- a/ShadowsocksX-NG/SWBQRCodeWindowController.h
+++ b/ShadowsocksX-NG/SWBQRCodeWindowController.h
@@ -11,6 +11,7 @@
 
 @interface SWBQRCodeWindowController : NSWindowController
 
+@property (nonatomic, copy) NSString *legacyQRCode;
 @property (nonatomic, copy) NSString *qrCode;
 @property (nonatomic, copy) NSString *title;
 

--- a/ShadowsocksX-NG/SWBQRCodeWindowController.m
+++ b/ShadowsocksX-NG/SWBQRCodeWindowController.m
@@ -78,4 +78,13 @@
     [pasteboard writeObjects:copiedObjects];
 }
 
+- (void)flagsChanged:(NSEvent *)event {
+    NSUInteger modifiers = event.modifierFlags & NSDeviceIndependentModifierFlagsMask;
+    if (modifiers & NSAlternateKeyMask) {
+        [self setQRCode:self.legacyQRCode];
+    } else {
+        [self setQRCode:self.qrCode];
+    }
+}
+
 @end

--- a/ShadowsocksX-NG/ServerProfile.swift
+++ b/ShadowsocksX-NG/ServerProfile.swift
@@ -300,6 +300,7 @@ class ServerProfile: NSObject, NSCopying {
         comps.host = serverHost
         comps.port = Int(serverPort)
         comps.user = userInfo
+        comps.path = "/"  // This is required by SIP0002 for URLs with fragment or query
         comps.fragment = remark
         comps.queryItems = items
 

--- a/ShadowsocksX-NG/ServerProfile.swift
+++ b/ShadowsocksX-NG/ServerProfile.swift
@@ -31,7 +31,7 @@ class ServerProfile: NSObject, NSCopying {
         self.uuid = uuid
     }
 
-    convenience init?(url: URL?) {
+    convenience init?(url: URL) {
         self.init()
 
         func padBase64(string: String) -> String {
@@ -44,14 +44,12 @@ class ServerProfile: NSObject, NSCopying {
             }
         }
 
-        func decodeUrl(url: URL?) -> String? {
-            guard let urlStr = url?.absoluteString else {
-                return nil
-            }
+        func decodeUrl(url: URL) -> String? {
+            let urlStr = url.absoluteString
             let index = urlStr.index(urlStr.startIndex, offsetBy: 5)
             let encodedStr = urlStr.substring(from: index)
             guard let data = Data(base64Encoded: padBase64(string: encodedStr)) else {
-                return url?.absoluteString
+                return url.absoluteString
             }
             guard let decoded = String(data: data, encoding: String.Encoding.utf8) else {
                 return nil

--- a/ShadowsocksX-NG/Utils.m
+++ b/ShadowsocksX-NG/Utils.m
@@ -56,7 +56,10 @@ void ScanQRCodeOnScreen() {
             NSLog(@"%@", feature.messageString);
             if ( [feature.messageString hasPrefix:@"ss://"] )
             {
-                [foundSSUrls addObject:[NSURL URLWithString:feature.messageString]];
+                NSURL *url = [NSURL URLWithString:feature.messageString];
+                if (url) {
+                    [foundSSUrls addObject:url];
+                }
             }
         }
          CGImageRelease(image);

--- a/ShadowsocksX-NGTests/ServerProfileTests.swift
+++ b/ShadowsocksX-NGTests/ServerProfileTests.swift
@@ -135,6 +135,40 @@ class ServerProfileTests: XCTestCase {
         XCTAssertNil(profile)
     }
 
+    func testInitWithSIP002URL() {
+        // "ss://aes-256-cfb:password@example.com:8388?Remark=Prism&OTA=true"
+        let url = URL(string: "ss://YWVzLTI1Ni1jZmI6cGFzc3dvcmQ=@example.com:8388/?Remark=Prism&OTA=true")!
+
+        let profile = ServerProfile(url: url)
+
+        XCTAssertNotNil(profile)
+
+        XCTAssertEqual(profile?.serverHost, "example.com")
+        XCTAssertEqual(profile?.serverPort, 8388)
+        XCTAssertEqual(profile?.method, "aes-256-cfb")
+        XCTAssertEqual(profile?.password, "password")
+        XCTAssertEqual(profile?.remark, "Prism")
+        XCTAssertEqual(profile?.ota, true)
+    }
+
+    func testInitWithSIP002URLProfileName() {
+        let url = URL(string: "ss://YWVzLTI1Ni1jZmI6cGFzc3dvcmQ=@example.com:8388/#Name")!
+
+        let profile = ServerProfile(url: url)
+
+        XCTAssertNotNil(profile)
+        XCTAssertEqual(profile?.remark, "Name")
+    }
+
+    func testInitWithSIP002URLProfileNameOverride() {
+        let url = URL(string: "ss://YWVzLTI1Ni1jZmI6cGFzc3dvcmQ=@example.com:8388/?Remark=Name#Overriden")!
+
+        let profile = ServerProfile(url: url)
+
+        XCTAssertNotNil(profile)
+        XCTAssertEqual(profile?.remark, "Overriden")
+    }
+
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measure {

--- a/ShadowsocksX-NGTests/ServerProfileTests.swift
+++ b/ShadowsocksX-NGTests/ServerProfileTests.swift
@@ -31,7 +31,7 @@ class ServerProfileTests: XCTestCase {
     }
 
     func testInitWithSelfGeneratedURL() {
-        let newProfile = ServerProfile.init(url: profile.URL())
+        let newProfile = ServerProfile.init(url: profile.URL()!)
 
         XCTAssertEqual(newProfile?.serverHost, profile.serverHost)
         XCTAssertEqual(newProfile?.serverPort, profile.serverPort)
@@ -42,7 +42,7 @@ class ServerProfileTests: XCTestCase {
     }
 
     func testInitWithPlainURL() {
-        let url = URL(string: "ss://aes-256-cfb:password@example.com:8388")
+        let url = URL(string: "ss://aes-256-cfb:password@example.com:8388")!
 
         let profile = ServerProfile(url: url)
 
@@ -57,7 +57,7 @@ class ServerProfileTests: XCTestCase {
     }
 
     func testInitWithPlainURLandQuery() {
-        let url = URL(string: "ss://aes-256-cfb:password@example.com:8388?Remark=Prism&OTA=true")
+        let url = URL(string: "ss://aes-256-cfb:password@example.com:8388?Remark=Prism&OTA=true")!
 
         let profile = ServerProfile(url: url)
 
@@ -72,7 +72,7 @@ class ServerProfileTests: XCTestCase {
     }
 
     func testInitWithPlainURLandAnotherQuery() {
-        let url = URL(string: "ss://aes-256-cfb:password@example.com:8388?Remark=Prism&OTA=0")
+        let url = URL(string: "ss://aes-256-cfb:password@example.com:8388?Remark=Prism&OTA=0")!
 
         let profile = ServerProfile(url: url)
 
@@ -88,7 +88,7 @@ class ServerProfileTests: XCTestCase {
 
     func testInitWithBase64EncodedURL() {
         // "ss://aes-256-cfb:password@example.com:8388"
-        let url = URL(string: "ss://YWVzLTI1Ni1jZmI6cGFzc3dvcmRAZXhhbXBsZS5jb206ODM4OA")
+        let url = URL(string: "ss://YWVzLTI1Ni1jZmI6cGFzc3dvcmRAZXhhbXBsZS5jb206ODM4OA")!
 
         let profile = ServerProfile(url: url)
 
@@ -104,7 +104,7 @@ class ServerProfileTests: XCTestCase {
 
     func testInitWithBase64EncodedURLandQuery() {
         // "ss://aes-256-cfb:password@example.com:8388?Remark=Prism&OTA=true"
-        let url = URL(string: "ss://YWVzLTI1Ni1jZmI6cGFzc3dvcmRAZXhhbXBsZS5jb206ODM4OD9SZW1hcms9UHJpc20mT1RBPXRydWU")
+        let url = URL(string: "ss://YWVzLTI1Ni1jZmI6cGFzc3dvcmRAZXhhbXBsZS5jb206ODM4OD9SZW1hcms9UHJpc20mT1RBPXRydWU")!
 
         let profile = ServerProfile(url: url)
 
@@ -119,15 +119,7 @@ class ServerProfileTests: XCTestCase {
     }
 
     func testInitWithEmptyURL() {
-        let url = URL(string: "ss://")
-
-        let profile = ServerProfile(url: url)
-
-        XCTAssertNil(profile)
-    }
-
-    func testInitWithInvalidURL() {
-        let url = URL(string: "ss://invalid url")
+        let url = URL(string: "ss://")!
 
         let profile = ServerProfile(url: url)
 
@@ -136,7 +128,7 @@ class ServerProfileTests: XCTestCase {
 
     func testInitWithBase64EncodedInvalidURL() {
         // "ss://invalid url"
-        let url = URL(string: "ss://aW52YWxpZCB1cmw")
+        let url = URL(string: "ss://aW52YWxpZCB1cmw")!
 
         let profile = ServerProfile(url: url)
 


### PR DESCRIPTION
This PR mainly adds SIP002 QR code support.

* The scanner now can recognize both legacy and SIP002 URI Schemes.
* The QR code dialog now shows the SIP002 QR code by default, and you can switch to the legacy one by holding down the option key.
* A bug is fixed that it may crash when a malicious URL is scanned.

One thing to notice is that since SIP002 is using the URL fragment to store Profile Name, I made it a higher priority choice over the original `Remark` query argument. i.e. For an SIP002 URL like `ss://UU@HH:PP/?Remark=RemarkName#ProfileName`, the resulting remark will be `ProfileName` instead of `RemarkName`. This does not affect the legacy URL Scheme.

Now the Android version can scan QR codes from SSX-NG correctly, fixes #433