### PR TITLE
Fixes #348 Prevent cascading toast window

### DIFF
--- a/ShadowsocksX-NG/ToastWindowController.swift
+++ b/ShadowsocksX-NG/ToastWindowController.swift
@@ -30,6 +30,8 @@ class ToastWindowController: NSWindowController {
     override func windowDidLoad() {
         super.windowDidLoad()
 
+        self.shouldCascadeWindows = false
+
         // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
         if let win = self.window {
             win.isOpaque = false


### PR DESCRIPTION
The default behavior of `NSWindowController` cascades its window with others, resulting in the movement of the toast window. Setting `shouldCascadeWindows` to `false` resolves the issue.