### PR TITLE
Fix ss_local cannot start issue on Mac 10.12.6

### DIFF
--- a/ShadowsocksX-NG/start_kcptun.sh
+++ b/ShadowsocksX-NG/start_kcptun.sh
@@ -6,5 +6,6 @@
 #  Created by 邱宇舟 on 2017/1/11.
 #  Copyright © 2017年 qiuyuzhou. All rights reserved.
 
+chmod 444 "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.kcptun.plist"
 launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.kcptun.plist"
 launchctl start com.qiuyuzhou.shadowsocksX-NG.kcptun

--- a/ShadowsocksX-NG/start_privoxy.sh
+++ b/ShadowsocksX-NG/start_privoxy.sh
@@ -6,5 +6,6 @@
 #  Created by 王晨 on 16/10/7.
 #  Copyright © 2016年 zhfish. All rights reserved.
 
+chmod 444 "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
 launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
 launchctl start com.qiuyuzhou.shadowsocksX-NG.http

--- a/ShadowsocksX-NG/start_ss_local.sh
+++ b/ShadowsocksX-NG/start_ss_local.sh
@@ -6,5 +6,6 @@
 #  Created by 邱宇舟 on 16/6/6.
 #  Copyright © 2016年 qiuyuzhou. All rights reserved.
 
+chmod 444 "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
 launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
 launchctl start com.qiuyuzhou.shadowsocksX-NG.local


### PR DESCRIPTION
`launchctl load` failed with error: "Path has bad ownership/permissions"

Removed the write permission for plist.