### PR TITLE
Fixes typos and styling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,23 @@ Next Generation of [ShadowsocksX](https://github.com/shadowsocks/shadowsocks-iOS
 ## Why?
 
 It's hard to maintain the original implementation as there is too much unused code in it.
-It also embeds the ss-local source. It's crazy to maintain dependencies of ss-local.
-So it's hard to update the ss-local version.
+It also embeds the `ss-local` source. It's crazy to maintain dependencies of `ss-local`.
+So it's hard to update the `ss-local` version.
 
-Now I just copied the ss-local from homebrew. Run ss-local executable as a Launch Agent in the background.
-Serve PAC js file as a file URL. So there is only some source code related to GUI left.
+Now I just copied the `ss-local` from Homebrew. Run `ss-local` executable as a Launch Agent in the background.
+Serve PAC JS file as a file URL. So there is only some source code related to GUI left.
 Then I will rewrite the GUI code in Swift.
 
 ## Requirements
 
 ### Running
 
-- Mac OS X 10.11 +
+- macOS 10.11+
 
 ### Building
 
-- XCode 8.3+
-- cocoapod 1.2+
+- Xcode 8.3+
+- CocoaPods 1.2+
 
 ## Download
 
@@ -33,8 +33,8 @@ From [here](https://github.com/shadowsocks/ShadowsocksX-NG/releases/)
 
 ## Features
 
-- Use ss-local from shadowsocks-libev 3.0.5
-- Could Update PAC by download GFW List from GitHub.
+- Use `ss-local` from shadowsocks-libev 3.0.5
+- Could update PAC by download GFW List from GitHub.
 - Show QRCode for current server profile.
 - Scan QRCode from screen.
 - Auto launch at login.
@@ -44,28 +44,28 @@ From [here](https://github.com/shadowsocks/ShadowsocksX-NG/releases/)
 - Over [kcptun](https://github.com/xtaci/kcptun). Version 20170322
 - Export/Import configure file.
 - An advanced preferences panel to configure:
-	- Local socks5 listen address.
-	- Local socks5 listen port.
-	- Local socks5 timeout.
+	- Local SOCKS5 listen address.
+	- Local SOCKS5 listen port.
+	- Local SOCKS5 timeout.
 	- If enable UDP relay.
 	- GFW List URL.
 - Manual specify network service profiles which would be configure the proxy.
 - Could reorder shadowsocks profiles by drag & drop in servers preferences panel.
 - Configurable global shortcuts for toggle running and switch proxy mode.
 
-## Different from orignal ShadowsocksX
+## Different from original ShadowsocksX
 
-Run ss-local as a background service through launchd, not as an in-app process.
-So after you quit the app, the ss-local maybe be still running.
+Run `ss-local` as a background service through launchd, not as an in-app process.
+So after you quit the app, the `ss-local` maybe be still running.
 
 Added a manual mode which won't configure the system proxy settings.
-Then you could configure your apps to use the socks5 proxy manually.
+Then you could configure your apps to use the SOCKS5 proxy manually.
 
-## Contributing 
+## Contributing
 
 [![gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ShadowsocksX-NG/Lobby)
 
-Contributions must be available on a separately named branch based on the latest version of the main branch develop.
+Contributions must be available on a separately named branch based on the latest version of the main branch `develop`.
 
 ref: [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/)
 


### PR DESCRIPTION
This PR mainly fixes typos and styling in `README.md`.

Typos:
* orignal → original

Wording:
* Mac OS X → macOS
    * Apple's OS branding is complicated...
        * `Mac OS X` from 2000-10 to 2012-07
        * `OS X` from 2012-07 to 2016-09
        * `macOS` from 2016-09
* XCode → Xcode
* Cocoapod → CocoaPods
* js → JS
     * Although JavaScript may be better...
* homebrew → Homebrew
* socks5 → SOCKS5

Styling:
* ss-local → `ss-local`
    * `ss-local` is the filename of  an executable, so give it the code / path style.
* develop → `develop`
    * `develop` is the name of git branch. Another choice is to wrap it with quotes.