### PR TITLE
Fixes #490 by Quoting Script Path in Apple Script

### DIFF
--- a/ShadowsocksX-NG/ProxyConfHelper.m
+++ b/ShadowsocksX-NG/ProxyConfHelper.m
@@ -51,12 +51,12 @@ GCDWebServer *webServer =nil;
         NSString *helperPath = [NSString stringWithFormat:@"%@/%@", [[NSBundle mainBundle] resourcePath], @"install_helper.sh"];
         NSLog(@"run install script: %@", helperPath);
         NSDictionary *error;
-        NSString *script = [NSString stringWithFormat:@"do shell script \"bash %@\" with administrator privileges", helperPath];
+        NSString *script = [NSString stringWithFormat:@"do shell script \"/bin/bash \\\"%@\\\"\" with administrator privileges", helperPath];
         NSAppleScript *appleScript = [[NSAppleScript new] initWithSource:script];
         if ([appleScript executeAndReturnError:&error]) {
             NSLog(@"installation success");
         } else {
-            NSLog(@"installation failure");
+            NSLog(@"installation failure: %@", error);
         }
     }
 }


### PR DESCRIPTION
This PR fixes #490.

* Quotes the script path so that spaces in the path won't be regarded as argument separators.
* Appends the exact error in the log message for clear issue report and easier debugging.
* Also, `bash` is replaced with `/bin/bash` in the script, I believe it's safer.