### PR TITLE
Fix can’t launch the agents when macOS disable SIP(System Integrity P…

### DIFF
--- a/ShadowsocksX-NG/start_kcptun.sh
+++ b/ShadowsocksX-NG/start_kcptun.sh
@@ -7,5 +7,5 @@
 #  Copyright © 2017年 qiuyuzhou. All rights reserved.
 
 chmod 644 "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.kcptun.plist"
-launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.kcptun.plist"
+launchctl load -wF "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.kcptun.plist"
 launchctl start com.qiuyuzhou.shadowsocksX-NG.kcptun

--- a/ShadowsocksX-NG/start_privoxy.sh
+++ b/ShadowsocksX-NG/start_privoxy.sh
@@ -7,5 +7,5 @@
 #  Copyright © 2016年 zhfish. All rights reserved.
 
 chmod 644 "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
-launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
+launchctl load -wF "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
 launchctl start com.qiuyuzhou.shadowsocksX-NG.http

--- a/ShadowsocksX-NG/start_ss_local.sh
+++ b/ShadowsocksX-NG/start_ss_local.sh
@@ -7,5 +7,5 @@
 #  Copyright © 2016年 qiuyuzhou. All rights reserved.
 
 chmod 644 "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
-launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
+launchctl load -wF "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
 launchctl start com.qiuyuzhou.shadowsocksX-NG.local


### PR DESCRIPTION
每次开VPN之后都没法上网，没有错误提示，而且网上找不到有效的解决方法，困扰了我很长时间。
测试发现是launchctl load失败，对照官方的文档给launchctl load添加了强行加载plist的选项-wF。
修改后测试，关闭和开启SIP的电脑都能正常启动，没有任何副作用。